### PR TITLE
feat(CLI): allow specifying case

### DIFF
--- a/crates/cargo_witgen/src/opt.rs
+++ b/crates/cargo_witgen/src/opt.rs
@@ -11,12 +11,24 @@ pub struct Opt {
 
 #[derive(Parser, Debug)]
 pub enum Command {
-    /// Generate wit files
+    /// Generate wit files.
+    /// 
+    /// String options for identifiers and types:
+    /// 
+    /// "LOWER_CAMEL_CASE", "UPPER_CAMEL_CASE", "SNEK_CASE", "KEBAB_CASE" (default).
     #[clap(alias = "gen")]
     Generate {
         /// Specify output file to generate wit definitions
         #[clap(long, short = 'o')]
         output: Option<PathBuf>,
+
+        /// Style of type names
+        #[clap(long, short = 't')]
+        types: Option<String>,
+
+        /// Style of identifer names
+        #[clap(long, short = 'i')]
+        idents: Option<String>,
 
         /// Arguments to be passed to `cargo rustc ...`.
         #[clap(last = true)]

--- a/crates/witgen_macro/src/generator.rs
+++ b/crates/witgen_macro/src/generator.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use cargo_metadata::MetadataCommand;
 use syn::{Attribute, ItemEnum, ItemFn, ItemStruct, ItemType, Lit, ReturnType, Type};
 
-use crate::{is_known_keyword, options::style_ident, ToWitType};
+use crate::{is_known_keyword, options::{style_ident, style_type}, ToWitType};
 
 pub(crate) fn get_target_dir() -> PathBuf {
     let metadata = MetadataCommand::new()
@@ -155,7 +155,7 @@ pub(crate) fn gen_wit_function(func: &ItemFn) -> Result<String> {
                 };
                 is_known_keyword(&pat)?;
 
-                let ty = typed_pat.ty.to_wit()?;
+                let ty = style_type(&typed_pat.ty.to_wit()?);
                 Ok(format!("{}: {}", pat, ty))
             }
         })
@@ -172,7 +172,7 @@ pub(crate) fn gen_wit_function(func: &ItemFn) -> Result<String> {
                 .join(", ");
             writeln!(&mut content, " -> ({})", tuple_fields).context("cannot write return type")?;
         } else {
-            writeln!(&mut content, " -> {}", return_ty.to_wit()?)
+            writeln!(&mut content, " -> {}", style_type(&return_ty.to_wit()?))
                 .context("cannot write return type")?;
         }
     }

--- a/crates/witgen_macro/src/lib.rs
+++ b/crates/witgen_macro/src/lib.rs
@@ -17,6 +17,7 @@ use syn::{parse, ItemEnum, ItemFn, ItemStruct, ItemType, Type};
 use crate::generator::gen_wit_type_alias;
 
 mod generator;
+mod options;
 
 static TARGET_PATH: OnceCell<PathBuf> = OnceCell::new();
 
@@ -183,9 +184,7 @@ impl ToWitType for Type {
                             }
                             "usize" => String::from("u64"),
                             "isize" => String::from("i64"),
-                            ident
-                            @
-                            ("f32" | "f64" | "u8" | "u16" | "u32" | "u64" | "char"
+                            ident @ ("f32" | "f64" | "u8" | "u16" | "u32" | "u64" | "char"
                             | "bool") => ident.to_string(),
                             ident => {
                                 let ident_formatted = ident.to_string().to_kebab_case();

--- a/crates/witgen_macro/src/options.rs
+++ b/crates/witgen_macro/src/options.rs
@@ -1,6 +1,8 @@
 use heck::{ToKebabCase, ToLowerCamelCase, ToSnekCase, ToUpperCamelCase};
 use proc_macro2::Ident;
 
+use crate::is_known_keyword;
+
 const IDENT_STYLE: &str = "IDENT_STYLE";
 const TYPE_STYLE: &str = "TYPE_STYLE";
 
@@ -52,5 +54,22 @@ pub(crate) fn get_type_style_env() -> String {
 }
 
 pub fn style_ident(ident: &Ident, is_type: bool) -> String {
-    StringCase::format_str(ident.to_string(), is_type)
+    let ident = ident.to_string();
+    if is_type && is_wit_primitive(&ident) {
+        ident
+    } else {
+        StringCase::format_str(ident, is_type)
+    }
+}
+
+fn is_wit_primitive(ident: &str) -> bool {
+  is_known_keyword(&ident).is_err() || ident.contains("<")
+}
+
+pub fn style_type(ident: &str) -> String {
+    if is_wit_primitive(ident) {
+      ident.to_string()
+    } else {
+      StringCase::format_str(ident.to_string(), true)
+    }
 }

--- a/crates/witgen_macro/src/options.rs
+++ b/crates/witgen_macro/src/options.rs
@@ -1,0 +1,56 @@
+use heck::{ToKebabCase, ToLowerCamelCase, ToSnekCase, ToUpperCamelCase};
+use proc_macro2::Ident;
+
+const IDENT_STYLE: &str = "IDENT_STYLE";
+const TYPE_STYLE: &str = "TYPE_STYLE";
+
+const LOWER_CAMEL_CASE: &str = "LOWER_CAMEL_CASE";
+const UPPER_CAMEL_CASE: &str = "UPPER_CAMEL_CASE";
+const SNEK_CASE: &str = "SNEK_CASE";
+const SNAKE_CASE: &str = "SNAKE_CASE";
+const KEBAB_CASE: &str = "KEBAB_CASE";
+
+enum StringCase {
+    LowerCamel,
+    Kebab,
+    Snake,
+    UpperCamel,
+}
+
+impl StringCase {
+    fn get_from_env(is_type: bool) -> Self {
+        let style = if is_type {
+            get_type_style_env()
+        } else {
+            get_ident_style_env()
+        };
+        match style.as_str() {
+            LOWER_CAMEL_CASE => StringCase::LowerCamel,
+            SNEK_CASE | SNAKE_CASE => StringCase::Snake,
+            UPPER_CAMEL_CASE => StringCase::UpperCamel,
+            _ => StringCase::Kebab,
+        }
+    }
+
+    fn format_str(s: String, is_type: bool) -> String {
+        use StringCase::*;
+        match StringCase::get_from_env(is_type) {
+            LowerCamel => s.to_lower_camel_case(),
+            Kebab => s.to_kebab_case(),
+            Snake => s.to_snek_case(),
+            UpperCamel => s.to_upper_camel_case(),
+        }
+    }
+}
+
+pub(crate) fn get_ident_style_env() -> String {
+    std::env::var(IDENT_STYLE).unwrap_or_else(|_| KEBAB_CASE.to_string())
+}
+
+pub(crate) fn get_type_style_env() -> String {
+    std::env::var(TYPE_STYLE).unwrap_or_else(|_| KEBAB_CASE.to_string())
+}
+
+pub fn style_ident(ident: &Ident, is_type: bool) -> String {
+    StringCase::format_str(ident.to_string(), is_type)
+}


### PR DESCRIPTION
Adds `--types` `--idents` options for allowing users to pick how the strings will appear in `wit` document.
