### PR TITLE
fix(wit): remove extra spaces between keywords and generic

### DIFF
--- a/crates/witgen_macro/src/lib.rs
+++ b/crates/witgen_macro/src/lib.rs
@@ -111,10 +111,10 @@ impl ToWitType for Type {
     fn to_wit(&self) -> Result<String> {
         let res = match self {
             Type::Array(array) => {
-                format!("list <{}>", array.elem.to_wit()?)
+                format!("list<{}>", array.elem.to_wit()?)
             }
             Type::Slice(array) => {
-                format!("list <{}>", array.elem.to_wit()?)
+                format!("list<{}>", array.elem.to_wit()?)
             }
             Type::Path(path) => {
                 let last_path_seg = path.path.segments.last().ok_or_else(|| {
@@ -138,7 +138,7 @@ impl ToWitType for Type {
                                         "Option" => "option",
                                         _ => unreachable!(),
                                     };
-                                    format!("{} <{}>", new_ty_name, ty.to_wit()?)
+                                    format!("{}<{}>", new_ty_name, ty.to_wit()?)
                                 }
                                 other => {
                                     bail!("generic args type {:?} is not implemented", other)
@@ -166,7 +166,7 @@ impl ToWitType for Type {
                                 })
                                 .collect::<Result<Vec<String>>>()?;
 
-                            format!("expected <{}>", generic_args.join(", "))
+                            format!("expected<{}>", generic_args.join(", "))
                         }
                         syn::PathArguments::Parenthesized(_) | syn::PathArguments::None => {
                             bail!("parenthized path argument is not implemented")

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -1,18 +1,22 @@
 // This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command
 
-test-option: function(other: list <u8>, number: u8, othernum: s32) -> option <tuple<string, u64>>
+///  Here is a doc example to generate in wit file
+record test-bis {
+    coucou: string,
+	btes: list<u8>
+}
 
-test-simple: function(array: list <u8>) -> string
+test-simple: function(array: list<u8>) -> string
+
+test-tuple: function(other: list<u8>, test-struct: test-struct, other-enum: test-enum) -> (string, s64)
+
+test-result: function(other: list<u8>, number: u8, othernum: s32) -> expected<tuple<string, u64>, string>
 
 ///  Documentation over struct
 ///  in multi-line
 type test-tuple = tuple<u64, string>
 
-test-array: function(other: list <u8>, number: u8, othernum: s32) -> (string, u64)
-
-test-vec: function(other: list <u8>, number: u8, othernum: s32) -> (string, u64)
-
-test-tuple: function(other: list <u8>, test-struct: test-struct, other-enum: test-enum) -> (string, s64)
+test-option: function(other: list<u8>, number: u8, othernum: s32) -> option<tuple<string, u64>>
 
 variant my-enum {
     unit,
@@ -24,6 +28,8 @@ record test-struct {
 	inner: string
 }
 
+test-array: function(other: list<u8>, number: u8, othernum: s32) -> (string, u64)
+
 ///  Documentation over enum
 variant test-enum {
     ///  Doc comment over Unit variant in struct
@@ -33,11 +39,5 @@ variant test-enum {
 	string-variant(string),
 }
 
-test-result: function(other: list <u8>, number: u8, othernum: s32) -> expected <tuple<string, u64>, string>
-
-///  Here is a doc example to generate in wit file
-record test-bis {
-    coucou: string,
-	btes: list <u8>
-}
+test-vec: function(other: list<u8>, number: u8, othernum: s32) -> (string, u64)
 


### PR DESCRIPTION
From the [format "spec"](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md) there are no spaces between keywords and generics.  E.g. `list<u8>`.  

If this was a personal preference then perhaps it's worth adding another CLI option.
