### PR TITLE
feat: add HashMap support

### DIFF
--- a/crates/witgen_macro_helper/src/lib.rs
+++ b/crates/witgen_macro_helper/src/lib.rs
@@ -102,6 +102,28 @@ impl ToWitType for Type {
                             bail!("parenthized path argument is not implemented")
                         }
                     },
+                    wrapper_ty @ "HashMap" => match &last_path_seg.arguments {
+                        syn::PathArguments::AngleBracketed(generic_args) => {
+                            if generic_args.args.len() != 2 {
+                                bail!("generic args of {} should be 2", wrapper_ty);
+                            }
+
+                            let args = generic_args
+                                .args
+                                .iter()
+                                .map(|arg| match arg {
+                                    syn::GenericArgument::Type(ty) => ty.to_wit(),
+                                    other => {
+                                        bail!("generic args type {:?} is not implemented", other)
+                                    }
+                                })
+                                .collect::<Result<Vec<String>>>()?;
+                            format!("list<tuple<{}>>", args.join(","))
+                        }
+                        syn::PathArguments::Parenthesized(_) | syn::PathArguments::None => {
+                            bail!("parenthized path argument is not implemented")
+                        }
+                    },
                     wrapper_ty @ "Result" => match &last_path_seg.arguments {
                         syn::PathArguments::AngleBracketed(generic_args) => {
                             if generic_args.args.len() > 2 {

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code, unused_variables)]
+use std::collections::HashMap;
+
 use witgen::witgen;
 
 #[witgen]
@@ -72,4 +74,10 @@ enum TestEnum {
 #[witgen]
 fn test_tuple(other: Vec<u8>, test_struct: TestStruct, other_enum: TestEnum) -> (String, i64) {
     (String::from("test"), 0i64)
+}
+
+
+#[witgen]
+struct HasHashMap {
+  map: HashMap<String, TestStruct>,
 }

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -23,6 +23,10 @@ type test-tuple = tuple<u64, string>
 
 test-option: function(other: list<u8>, number: u8, othernum: s32) -> option<tuple<string, u64>>
 
+record has-hash-map {
+    map: list<tuple<string,test-struct>>
+}
+
 variant my-enum {
     unit,
 	tuple-variant(tuple<string, s32>),


### PR DESCRIPTION
Since `wit` does not have a map type, this PR add support for encoding `HashMap`'s as a list of tuples of key/value pairs.

See https://github.com/bytecodealliance/wit-bindgen/issues/108