### PR TITLE
feat: add two CLI options for adding to top of file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,8 @@ categories = ["wasm", "development-tools", "encoding"]
 [dependencies]
 witgen_macro = { path = "crates/witgen_macro", version = "0.6" }
 
+[dev-dependencies]
+trybuild = "1.0.54"
+
 [workspace]
 members = ["crates/witgen_macro", "crates/cargo_witgen", "examples/my_witgen_example"]

--- a/crates/cargo_witgen/src/main.rs
+++ b/crates/cargo_witgen/src/main.rs
@@ -85,7 +85,7 @@ fn run_generate(target_dir: &Path, cli_args: crate::opt::Command) -> Result<()> 
     let mut generated_comment = format!("// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v{}) \n\n", env!("CARGO_PKG_VERSION"));
 
     if let Some(path) = prefix_file {
-      let prefix_file = String::from_utf8(read(path).expect("cannot read prefix_file"))?;
+      let prefix_file = String::from_utf8(read(path)?)?;
       generated_comment.push_str(&format!("{}\n\n", prefix_file));
     }
     if let Some(prefix) = prefix_string {

--- a/crates/cargo_witgen/src/opt.rs
+++ b/crates/cargo_witgen/src/opt.rs
@@ -21,5 +21,14 @@ pub enum Command {
         /// Arguments to be passed to `cargo rustc ...`.
         #[clap(last = true)]
         args: Vec<String>,
+
+        /// Specify prefix file to copy into top of the generated wit file
+        #[clap(long, short = 'p')]
+        prefix_file: Option<PathBuf>,
+
+        /// Specify prefix string to copy into top of the generated wit file
+        /// `--prefix-string 'use * from "string.wit"'`
+        #[clap(long, short = 's')]
+        prefix_string: Option<String>,
     },
 }

--- a/examples/my_witgen_example/src/extra_type.rs
+++ b/examples/my_witgen_example/src/extra_type.rs
@@ -1,0 +1,3 @@
+
+
+pub type StringAlias = String;

--- a/examples/my_witgen_example/string.wit
+++ b/examples/my_witgen_example/string.wit
@@ -1,0 +1,1 @@
+type string-alias = string

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -1,12 +1,14 @@
 // This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.6.0) 
 
-///  Here is a doc example to generate in wit file
+use * from "string.wit"///  Here is a doc example to generate in wit file
 record test-bis {
     coucou: string,
 	btes: list<u8>
 }
 
 test-simple: function(array: list<u8>) -> string
+
+use-string-alias: function(s: string-alias) -> string-alias
 
 test-tuple: function(other: list<u8>, test-struct: test-struct, other-enum: test-enum) -> (string, s64)
 

--- a/tests/files/success.rs
+++ b/tests/files/success.rs
@@ -1,9 +1,6 @@
 #![allow(dead_code, unused_variables)]
 use std::collections::HashMap;
 
-mod extra_type;
-use extra_type::*;
-
 use witgen::witgen;
 
 #[witgen]
@@ -79,12 +76,10 @@ fn test_tuple(other: Vec<u8>, test_struct: TestStruct, other_enum: TestEnum) -> 
     (String::from("test"), 0i64)
 }
 
-#[witgen]
-struct HasHashMap {
-    map: HashMap<String, TestStruct>,
-}
 
 #[witgen]
-fn use_string_alias(s: StringAlias) -> StringAlias {
-    s
+struct HasHashMap {
+  map: HashMap<String, TestStruct>,
 }
+
+pub fn main(){}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,7 @@
+
+#[test]
+fn test() {
+    let t = trybuild::TestCases::new();
+    std::env::set_var("WITGEN_ENABLED", "true");
+    t.pass("tests/files/success.rs");
+}


### PR DESCRIPTION
`--prefix-file` Will copy contents of file to top of the .wit file.
`--prefix-string` Will copy passed string to top of the .wit file.

Also added one test using try_build.  More to come to ensure good error messages.
