### PR TITLE
feat: allow reference types by using internal `elem`

### DIFF
--- a/crates/cargo_witgen/src/main.rs
+++ b/crates/cargo_witgen/src/main.rs
@@ -8,7 +8,7 @@ use once_cell::sync::OnceCell;
 
 use std::{
     env,
-    fs::{self, OpenOptions, read},
+    fs::{self, read, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
     process::Command,
@@ -85,11 +85,11 @@ fn run_generate(target_dir: &Path, cli_args: crate::opt::Command) -> Result<()> 
     let mut generated_comment = format!("// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v{}) \n\n", env!("CARGO_PKG_VERSION"));
 
     if let Some(path) = prefix_file {
-      let prefix_file = String::from_utf8(read(path)?)?;
-      generated_comment.push_str(&format!("{}\n\n", prefix_file));
+        let prefix_file = String::from_utf8(read(path)?)?;
+        generated_comment.push_str(&format!("{}\n\n", prefix_file));
     }
     if let Some(prefix) = prefix_string {
-      generated_comment.push_str(&format!("{}\n\n", prefix));
+        generated_comment.push_str(&format!("{}\n\n", prefix));
     }
 
     file.write_all(generated_comment.as_bytes())

--- a/crates/witgen_macro_helper/src/generator.rs
+++ b/crates/witgen_macro_helper/src/generator.rs
@@ -15,7 +15,6 @@ pub fn get_target_dir() -> PathBuf {
     metadata.target_directory.join("witgen").into()
 }
 
-
 /// Generate a wit record
 /// ```rust
 /// /// Document String
@@ -33,7 +32,7 @@ pub fn get_target_dir() -> PathBuf {
 ///   b: option<s32>,
 /// }
 /// ```
-/// 
+///
 pub fn gen_wit_struct(strukt: &ItemStruct) -> Result<String> {
     if !strukt.generics.params.is_empty() {
         bail!("doesn't support generic parameters with witgen");
@@ -99,7 +98,7 @@ pub fn gen_wit_struct(strukt: &ItemStruct) -> Result<String> {
 ///   TupleVariant(String, i32)
 /// }
 /// ```
-/// 
+///
 /// ```ts
 /// /// Top comment
 /// variant my-enum {
@@ -182,7 +181,7 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
 /// /// Document String
 /// foo: function(a: string, b: option<s32>) -> expected<string>
 /// ```
-/// 
+///
 pub fn gen_wit_function(func: &ItemFn) -> Result<String> {
     let signature = &func.sig;
     let comment = get_doc_comment(&func.attrs)?;
@@ -232,7 +231,6 @@ pub fn gen_wit_function(func: &ItemFn) -> Result<String> {
     }
 }
 
-
 /// Generate a wit type alias
 /// ```rust
 /// /// Document String
@@ -243,7 +241,7 @@ pub fn gen_wit_function(func: &ItemFn) -> Result<String> {
 /// /// Document String
 /// type foo = tuple<string, option<bool>>
 /// ```
-/// 
+///
 pub fn gen_wit_type_alias(type_alias: &ItemType) -> Result<String> {
     if !type_alias.generics.params.is_empty() {
         bail!("doesn't support generic parameters with witgen");

--- a/crates/witgen_macro_helper/src/lib.rs
+++ b/crates/witgen_macro_helper/src/lib.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Result};
 use heck::ToKebabCase;
 
 use quote::ToTokens;
-use syn::Type;
+use syn::{Type, TypeReference};
 
 mod generator;
 pub use generator::{
@@ -180,7 +180,10 @@ impl ToWitType for Type {
                         .join(", ")
                 )
             }
-
+            Type::Reference(r) => {
+              let TypeReference {elem, ..}  = r;
+              return elem.to_wit();
+            }
             _ => bail!(
                 "cannot serialize this type '{}' to wit",
                 self.to_token_stream()
@@ -198,7 +201,7 @@ pub fn hash_string(query: &str) -> String {
 }
 
 pub fn write_to_file_default(content: String) -> Result<()> {
-  write_to_file(&get_or_init_target_dir(), content)
+    write_to_file(&get_or_init_target_dir(), content)
 }
 
 pub fn write_to_file(target_dir: &PathBuf, content: String) -> Result<()> {


### PR DESCRIPTION
In my use case exported functions can use `&Type` because it gets deserialized.  So from the caller's perspective it is `Type`.

If you don't want this feature then perhaps we can add a CLI arg or ENV variable as a flag.