### PR TITLE
feat: add enum if variant only has units

### DIFF
--- a/crates/witgen_macro_helper/src/generator.rs
+++ b/crates/witgen_macro_helper/src/generator.rs
@@ -60,7 +60,7 @@ pub fn gen_wit_struct(strukt: &ItemStruct) -> Result<String> {
 
             let field_wit = format!("{}{}", field_name, field.ty.to_wit()?);
             match comment {
-                Some(comment) => Ok(format!("{}\t{}", comment, field_wit)),
+                Some(comment) => Ok(format!("{}    {}", comment, field_wit)),
                 None => Ok(field_wit),
             }
         })
@@ -68,7 +68,7 @@ pub fn gen_wit_struct(strukt: &ItemStruct) -> Result<String> {
     let attrs = if is_tuple_struct {
         attrs.join(", ")
     } else {
-        attrs.join(",\n\t")
+        attrs.join(",\n    ")
     };
 
     let content = if is_tuple_struct {
@@ -143,7 +143,7 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
                 };
 
                 match comment {
-                    Some(comment) => Ok(format!("{}\t{}", comment, variant_wit)),
+                    Some(comment) => Ok(format!("{}    {}", comment, variant_wit)),
                     None => Ok(variant_wit),
                 }
             }
@@ -152,13 +152,13 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
                 let variant_wit = variant.ident.to_string().to_kebab_case() + ",";
 
                 match comment {
-                    Some(comment) => Ok(format!("{}\t{}", comment, variant_wit)),
+                    Some(comment) => Ok(format!("{}    {}", comment, variant_wit)),
                     None => Ok(variant_wit),
                 }
             }
         })
         .collect::<Result<Vec<String>>>()?
-        .join("\n\t");
+        .join("\n    ");
         let ty = if is_wit_enum { "enum" } else {"variant"};
     let content = format!(
         r#"{ty} {enm_name} {{

--- a/crates/witgen_macro_helper/src/generator.rs
+++ b/crates/witgen_macro_helper/src/generator.rs
@@ -116,6 +116,7 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
     is_known_keyword(&enm_name)?;
 
     let comment = get_doc_comment(&enm.attrs)?;
+    let mut is_wit_enum = true;
     let variants = enm
         .variants
         .iter()
@@ -124,6 +125,7 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
                 "named variant fields are not already supported"
             )),
             syn::Fields::Unnamed(unamed) => {
+                is_wit_enum = false;
                 let comment = get_doc_comment(&variant.attrs)?;
                 let fields = unamed
                     .unnamed
@@ -157,12 +159,12 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
         })
         .collect::<Result<Vec<String>>>()?
         .join("\n\t");
+        let ty = if is_wit_enum { "enum" } else {"variant"};
     let content = format!(
-        r#"variant {} {{
-    {}
+        r#"{ty} {enm_name} {{
+    {variants}
 }}
-"#,
-        enm_name, variants
+"#
     );
 
     match comment {

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -7,6 +7,13 @@ use extra_type::*;
 use witgen::witgen;
 
 #[witgen]
+enum Colors {
+  Red,
+  Green,
+  Blue,
+}
+
+#[witgen]
 enum MyEnum {
     Unit,
     TupleVariant(String, i32),

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -1,6 +1,6 @@
-// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.6.0) 
+// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.8.0) 
 
-use * from "string.wit"///  Here is a doc example to generate in wit file
+///  Here is a doc example to generate in wit file
 record test-bis {
     coucou: string,
 	btes: list<u8>
@@ -37,6 +37,12 @@ variant my-enum {
 record test-struct {
     ///  Doc comment over inner field in struct
 	inner: string
+}
+
+enum colors {
+    red,
+	green,
+	blue,
 }
 
 type nft-contract-metadata = string

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -1,9 +1,17 @@
 // This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.8.0) 
 
-///  Here is a doc example to generate in wit file
-record test-bis {
-    coucou: string,
-	btes: list<u8>
+///  Documentation over enum
+variant test-enum {
+    ///  Doc comment over Unit variant in struct
+    unit,
+    number(u64),
+    ///  Doc comment over String variant in struct
+    string-variant(string),
+}
+
+variant my-enum {
+    unit,
+    tuple-variant(tuple<string, s32>),
 }
 
 test-simple: function(array: list<u8>) -> string
@@ -16,12 +24,23 @@ test-result: function(other: list<u8>, number: u8, othernum: s32) -> expected<tu
 
 record init-args {
     owner-id: string,
-	metadata: nft-contract-metadata
+    metadata: nft-contract-metadata
 }
 
 ///  Documentation over struct
 ///  in multi-line
 type test-tuple = tuple<u64, string>
+
+enum colors {
+    red,
+    green,
+    blue,
+}
+
+record test-struct {
+    ///  Doc comment over inner field in struct
+    inner: string
+}
 
 test-option: function(other: list<u8>, number: u8, othernum: s32) -> option<tuple<string, u64>>
 
@@ -29,33 +48,14 @@ record has-hash-map {
     map: list<tuple<string,test-struct>>
 }
 
-variant my-enum {
-    unit,
-	tuple-variant(tuple<string, s32>),
-}
-
-record test-struct {
-    ///  Doc comment over inner field in struct
-	inner: string
-}
-
-enum colors {
-    red,
-	green,
-	blue,
-}
-
 type nft-contract-metadata = string
 
 test-array: function(other: list<u8>, number: u8, othernum: s32) -> (string, u64)
 
-///  Documentation over enum
-variant test-enum {
-    ///  Doc comment over Unit variant in struct
-	unit,
-	number(u64),
-	///  Doc comment over String variant in struct
-	string-variant(string),
+///  Here is a doc example to generate in wit file
+record test-bis {
+    coucou: string,
+    btes: list<u8>
 }
 
 test-vec: function(other: list<u8>, number: u8, othernum: s32) -> (string, u64)


### PR DESCRIPTION
Takes advantage of `wit`'s `enum` alias.

Also switch tabs to four spaces as this is what wit examples use and makes spacing consistent.