### PR TITLE
feat: add support for named fields in variants

### DIFF
--- a/crates/witgen_macro_helper/src/generator.rs
+++ b/crates/witgen_macro_helper/src/generator.rs
@@ -3,7 +3,7 @@ use std::{fmt::Write, path::PathBuf};
 use anyhow::{bail, Context, Result};
 use cargo_metadata::MetadataCommand;
 use heck::ToKebabCase;
-use syn::{Attribute, ItemEnum, ItemFn, ItemStruct, ItemType, Lit, ReturnType, Type};
+use syn::{Attribute, Fields, ItemEnum, ItemFn, ItemStruct, ItemType, Lit, ReturnType, Type};
 
 use crate::{is_known_keyword, ToWitType};
 
@@ -116,61 +116,80 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
     is_known_keyword(&enm_name)?;
 
     let comment = get_doc_comment(&enm.attrs)?;
-    let mut is_wit_enum = true;
+    let is_wit_enum = enm
+        .variants
+        .iter()
+        .all(|v| matches!(v.fields, Fields::Unit));
+    let mut named_types = String::new();
     let variants = enm
         .variants
         .iter()
-        .map(|variant| match &variant.fields {
-            syn::Fields::Named(_named) => Err(anyhow::anyhow!(
-                "named variant fields are not already supported"
-            )),
-            syn::Fields::Unnamed(unamed) => {
-                is_wit_enum = false;
-                let comment = get_doc_comment(&variant.attrs)?;
-                let fields = unamed
-                    .unnamed
-                    .iter()
-                    .map(|field| field.ty.to_wit())
-                    .collect::<Result<Vec<String>>>()?
-                    .join(", ");
-                let variant_ident = variant.ident.to_string().to_kebab_case();
-                is_known_keyword(&variant_ident)?;
+        .map(|variant| {
+            let ident = variant.ident.to_string().to_kebab_case();
+            let comment = get_doc_comment(&variant.attrs)?;
+            let variant_string = match &variant.fields {
+                syn::Fields::Named(_named) => {
+                    let fields = _named
+                        .named
+                        .iter()
+                        .map(|field| {
+                            field.ty.to_wit().map(|ty| {
+                                let field_doc = get_doc_comment(&field.attrs)
+                                    .unwrap_or(None)
+                                    .as_ref()
+                                    .map_or("".to_string(), |s| format!("    {s}"));
 
-                let variant_wit = if unamed.unnamed.len() > 1 {
-                    format!("{}(tuple<{}>),", variant_ident, fields)
-                } else {
-                    format!("{}({}),", variant_ident, fields)
-                };
-
-                match comment {
-                    Some(comment) => Ok(format!("{}    {}", comment, variant_wit)),
-                    None => Ok(variant_wit),
+                                format!(
+                                    "{}    {}: {}",
+                                    field_doc,
+                                    field.ident.as_ref().unwrap(),
+                                    ty
+                                )
+                            })
+                        })
+                        .collect::<Result<Vec<String>>>()?
+                        .join(",\n");
+                    let inner_type_name = &format!("{enm_name}-{ident}");
+                    let comment = comment.as_deref().unwrap_or_default();
+                    named_types.push_str(&format!(
+                        "{comment}record {inner_type_name} {{\n{fields}\n}}\n"
+                    ));
+                    Ok(format!("{}({})", ident, inner_type_name))
                 }
-            }
-            syn::Fields::Unit => {
-                let comment = get_doc_comment(&variant.attrs)?;
-                let variant_wit = variant.ident.to_string().to_kebab_case() + ",";
+                syn::Fields::Unnamed(unamed) => {
+                    let fields = unamed
+                        .unnamed
+                        .iter()
+                        .map(|field| field.ty.to_wit())
+                        .collect::<Result<Vec<String>>>()?
+                        .join(", ");
+                    is_known_keyword(&ident)?;
 
-                match comment {
-                    Some(comment) => Ok(format!("{}    {}", comment, variant_wit)),
-                    None => Ok(variant_wit),
+                    Ok(if unamed.unnamed.len() > 1 {
+                        format!("{}(tuple<{}>),", ident, fields)
+                    } else {
+                        format!("{}({}),", ident, fields)
+                    })
                 }
-            }
+                syn::Fields::Unit => Ok(ident + ","),
+            };
+            let comment = comment.map_or("".to_string(), |s| format!("    {s}"));
+            variant_string.map(|v| format!("{}    {}", comment, v))
         })
         .collect::<Result<Vec<String>>>()?
-        .join("\n    ");
-        let ty = if is_wit_enum { "enum" } else {"variant"};
+        .join("\n");
+    let ty = if is_wit_enum { "enum" } else { "variant" };
     let content = format!(
         r#"{ty} {enm_name} {{
-    {variants}
+{variants}
 }}
 "#
     );
 
-    match comment {
-        Some(comment) => Ok(format!("{}{}", comment, content)),
-        None => Ok(content),
-    }
+    Ok(format!(
+        "{}{content}\n{named_types}",
+        comment.unwrap_or_default()
+    ))
 }
 
 /// Generate a wit function

--- a/crates/witgen_macro_helper/src/lib.rs
+++ b/crates/witgen_macro_helper/src/lib.rs
@@ -2,7 +2,7 @@
 use std::{
     fs::{self, OpenOptions},
     io::Write,
-    path::PathBuf,
+    path::{PathBuf, Path},
 };
 
 use anyhow::{bail, Context, Result};
@@ -204,7 +204,7 @@ pub fn write_to_file_default(content: String) -> Result<()> {
     write_to_file(&get_or_init_target_dir(), content)
 }
 
-pub fn write_to_file(target_dir: &PathBuf, content: String) -> Result<()> {
+pub fn write_to_file(target_dir: &Path, content: String) -> Result<()> {
     if std::env::var("WITGEN_ENABLED").map(|v| v.to_lowercase()) != Ok("true".to_string()) {
         return Ok(());
     }

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -20,6 +20,26 @@ enum MyEnum {
 }
 
 #[witgen]
+enum WithNamedFields {
+  /// Example variant with named fields
+  Example { 
+    /// Doc for inner string
+    name: String 
+  },
+  Unit,
+  ATuple(String),
+  /// Example of a big named field
+  BigExample { 
+    /// Info about field
+    field: u32,
+    b: bool,
+    s: String,
+    a: Vec<u32>,
+    a_tuple: (f64, HashMap<u32, WithNamedFields>)
+  }
+}
+
+#[witgen]
 fn test_simple(array: Vec<u8>) -> String {
     String::from("test")
 }

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -1,5 +1,44 @@
 // This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.8.0) 
 
+enum colors {
+    red,
+    green,
+    blue,
+}
+
+
+test-simple: function(array: list<u8>) -> string
+
+variant with-named-fields {
+    ///  Example variant with named fields
+    example(with-named-fields-example)
+    unit,
+    a-tuple(string),
+    ///  Example of a big named field
+    big-example(with-named-fields-big-example)
+}
+
+///  Example variant with named fields
+record with-named-fields-example {
+    ///  Doc for inner string
+    name: string
+}
+///  Example of a big named field
+record with-named-fields-big-example {
+    ///  Info about field
+    field: u32,
+    b: bool,
+    s: string,
+    a: list<u32>,
+    a_tuple: tuple<f64, list<tuple<u32,with-named-fields>>>
+}
+
+use-string-alias: function(s: string-alias) -> string-alias
+
+test-tuple: function(other: list<u8>, test-struct: test-struct, other-enum: test-enum) -> (string, s64)
+
+test-result: function(other: list<u8>, number: u8, othernum: s32) -> expected<tuple<string, u64>, string>
+
 ///  Documentation over enum
 variant test-enum {
     ///  Doc comment over Unit variant in struct
@@ -9,18 +48,6 @@ variant test-enum {
     string-variant(string),
 }
 
-variant my-enum {
-    unit,
-    tuple-variant(tuple<string, s32>),
-}
-
-test-simple: function(array: list<u8>) -> string
-
-use-string-alias: function(s: string-alias) -> string-alias
-
-test-tuple: function(other: list<u8>, test-struct: test-struct, other-enum: test-enum) -> (string, s64)
-
-test-result: function(other: list<u8>, number: u8, othernum: s32) -> expected<tuple<string, u64>, string>
 
 record init-args {
     owner-id: string,
@@ -31,11 +58,11 @@ record init-args {
 ///  in multi-line
 type test-tuple = tuple<u64, string>
 
-enum colors {
-    red,
-    green,
-    blue,
+variant my-enum {
+    unit,
+    tuple-variant(tuple<string, s32>),
 }
+
 
 record test-struct {
     ///  Doc comment over inner field in struct


### PR DESCRIPTION
Variants with fields are really just a special case of an unnamed field wrapping a record.  So this PR adds a record with the name `variant-type-name-field-name` and transforms the field into an unnamed one.  
For example,

```rust
enum Foo {
    NamedField { name: String }
}

```

becomes

```wit
variant foo {
    named-field(foo-named-field)
}

record foo-named-field {
    name: string
}
```
