### PR TITLE
fix: enums with named fields and add initial suite of tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ witgen_macro = { path = "crates/witgen_macro", version = "0.10" }
 
 [dev-dependencies]
 trybuild = "1.0.54"
+wit-parser = {git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f"}
+witgen_macro_helper = { path = "crates/witgen_macro_helper"}
+syn = { version = "1.0.82", features = ["full", "extra-traits"] }
+anyhow = "1.0.51"
 
 [workspace]
 members = ["crates/witgen_macro", "crates/cargo_witgen", "examples/my_witgen_example"]

--- a/crates/witgen_macro/src/lib.rs
+++ b/crates/witgen_macro/src/lib.rs
@@ -1,10 +1,7 @@
 #![deny(warnings)]
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use syn::{parse, ItemEnum, ItemFn, ItemStruct, ItemType};
-use witgen_macro_helper::{
-    gen_wit_enum, gen_wit_function, gen_wit_struct, gen_wit_type_alias, handle_error,
-};
+
+use witgen_macro_helper::parse_and_write_to_file;
 
 /// Proc macro attribute to help cargo-witgen to generate right definitions in `.wit` file
 /// ```no_run
@@ -29,34 +26,6 @@ use witgen_macro_helper::{
 /// ```
 #[proc_macro_attribute]
 pub fn witgen(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let strukt = parse::<ItemStruct>(item.clone());
-    if let Ok(strukt) = &strukt {
-        handle_error!(gen_wit_struct(strukt));
-        return item;
-    }
-
-    let func = parse::<ItemFn>(item.clone());
-    if let Ok(func) = &func {
-        handle_error!(gen_wit_function(func));
-        return item;
-    }
-
-    let enm = parse::<ItemEnum>(item.clone());
-    if let Ok(enm) = &enm {
-        handle_error!(gen_wit_enum(enm));
-        return item;
-    }
-
-    let type_alias = parse::<ItemType>(item.clone());
-    if let Ok(type_alias) = &type_alias {
-        handle_error!(gen_wit_type_alias(type_alias));
-        return item;
-    }
-
-    syn::Error::new_spanned(
-        proc_macro2::TokenStream::from(item),
-        "Cannot put wit_generator proc macro on this kind of item",
-    )
-    .to_compile_error()
-    .into()
+    parse_and_write_to_file(syn::parse::<proc_macro2::TokenStream>(item.clone()).unwrap())
+        .map_or(item, |s| s.into())
 }

--- a/crates/witgen_macro_helper/src/generator.rs
+++ b/crates/witgen_macro_helper/src/generator.rs
@@ -75,7 +75,7 @@ pub fn gen_wit_struct(strukt: &ItemStruct) -> Result<String> {
         format!("type {} = tuple<{}>\n", struct_name, attrs)
     } else {
         format!(
-r#"record {} {{
+            r#"record {} {{
     {}
 }}
 "#,
@@ -83,7 +83,7 @@ r#"record {} {{
         )
     };
 
-     Ok(format!("{}{}", comment.unwrap_or_default(), content))
+    Ok(format!("{}{}", comment.unwrap_or_default(), content))
 }
 
 /// Generate a wit enum
@@ -139,7 +139,7 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
                                 format!(
                                     "{}    {}: {}",
                                     field_doc,
-                                    field.ident.as_ref().unwrap(),
+                                    field.ident.as_ref().unwrap().to_string().to_kebab_case(),
                                     ty
                                 )
                             })
@@ -169,12 +169,12 @@ pub fn gen_wit_enum(enm: &ItemEnum) -> Result<String> {
                         fields
                     };
 
-                    Ok(format!("{}({}),", ident, formatted_field))
+                    Ok(format!("{}({})", ident, formatted_field))
                 }
-                syn::Fields::Unit => Ok(ident + ","),
+                syn::Fields::Unit => Ok(ident),
             };
             let comment = comment.map(|s| format!("    {}", s)).unwrap_or_default();
-            variant_string.map(|v| format!("{}    {}", comment, v))
+            variant_string.map(|v| format!("{}    {},", comment, v))
         })
         .collect::<Result<Vec<String>>>()?
         .join("\n");

--- a/examples/my_witgen_example/src/extra_type.rs
+++ b/examples/my_witgen_example/src/extra_type.rs
@@ -1,3 +1,1 @@
-
-
 pub type StringAlias = String;

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -8,9 +8,9 @@ use witgen::witgen;
 
 #[witgen]
 enum Colors {
-  Red,
-  Green,
-  Blue,
+    Red,
+    Green,
+    Blue,
 }
 
 #[witgen]
@@ -21,22 +21,22 @@ enum MyEnum {
 
 #[witgen]
 enum WithNamedFields {
-  /// Example variant with named fields
-  Example { 
-    /// Doc for inner string
-    name: String 
-  },
-  Unit,
-  ATuple(String),
-  /// Example of a big named field
-  BigExample { 
-    /// Info about field
-    field: u32,
-    b: bool,
-    s: String,
-    a: Vec<u32>,
-    a_tuple: (f64, HashMap<u32, WithNamedFields>)
-  }
+    /// Example variant with named fields
+    Example {
+        /// Doc for inner string
+        name: String,
+    },
+    Unit,
+    ATuple(String),
+    /// Example of a big named field
+    BigExample {
+        /// Info about field
+        field: u32,
+        b: bool,
+        s: String,
+        a: Vec<u32>,
+        a_tuple: (f64, HashMap<u32, WithNamedFields>),
+    },
 }
 
 #[witgen]

--- a/examples/my_witgen_example/witgen.wit
+++ b/examples/my_witgen_example/witgen.wit
@@ -1,4 +1,4 @@
-// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.9.0) 
+// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.10.0) 
 
 enum colors {
     red,
@@ -8,30 +8,6 @@ enum colors {
 
 
 test-simple: function(array: list<u8>) -> string
-
-variant with-named-fields {
-    ///  Example variant with named fields
-    example(with-named-fields-example)
-    unit,
-    a-tuple(string),
-    ///  Example of a big named field
-    big-example(with-named-fields-big-example)
-}
-
-///  Example variant with named fields
-record with-named-fields-example {
-    ///  Doc for inner string
-    name: string
-}
-///  Example of a big named field
-record with-named-fields-big-example {
-    ///  Info about field
-    field: u32,
-    b: bool,
-    s: string,
-    a: list<u32>,
-    a_tuple: tuple<f64, list<tuple<u32,with-named-fields>>>
-}
 
 use-string-alias: function(s: string-alias) -> string-alias
 
@@ -73,6 +49,30 @@ test-option: function(other: list<u8>, number: u8, othernum: s32) -> option<tupl
 
 record has-hash-map {
     map: list<tuple<string,test-struct>>
+}
+
+variant with-named-fields {
+    ///  Example variant with named fields
+    example(with-named-fields-example),
+    unit,
+    a-tuple(string),
+    ///  Example of a big named field
+    big-example(with-named-fields-big-example),
+}
+
+///  Example variant with named fields
+record with-named-fields-example {
+    ///  Doc for inner string
+    name: string
+}
+///  Example of a big named field
+record with-named-fields-big-example {
+    ///  Info about field
+    field: u32,
+    b: bool,
+    s: string,
+    a: list<u32>,
+    a-tuple: tuple<f64, list<tuple<u32,with-named-fields>>>
 }
 
 type nft-contract-metadata = string

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,46 @@
+use anyhow::Result;
+use wit_parser::Interface;
+
+fn parse_str(s: &str) -> Result<String> {
+    witgen_macro_helper::parse_str(s)
+}
+
+fn parse_wit_str(s: &str) -> Result<Interface> {
+    Interface::parse("a", s)
+}
+
+fn parse(s: &str) {
+    let res = parse_str(s).expect(s);
+    parse_wit_str(&res).expect(&res);
+}
 
 #[test]
 fn test() {
     let t = trybuild::TestCases::new();
     std::env::set_var("WITGEN_ENABLED", "true");
     t.pass("tests/files/success.rs");
+}
+
+#[test]
+fn enum_simple() {
+    let simple = "
+enum MyEnum {
+    Unit,
+    TupleVariant(String, i32),
+}
+";
+    parse(simple);
+}
+
+#[test]
+fn enum_complicated() {
+    let simple = "
+enum MyEnum {
+    Unit,
+    TupleVariant(String, i32),
+    HasNames { arg_one: u32, arg_two: String},
+    HasMoreNames { arg_one: u32, arg_two: String, arg_three: (String,), arg_bool: bool},
+}
+";
+    parse(simple);
 }


### PR DESCRIPTION
Never tested it with larger cases and it does fail to parse to wit.

However, this PR adds the initial tests for parsing the resulting wit so that we can properly test the output.

I covered the issue I had with the new tests, but plan on adding more tests in a following PR.

Also reworked the proc_macro so that all parsing logic is in the helper.