### PR TITLE
Feat: Make cargo-witgen into lib so that other CLI apps can reuse it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [0.12.0] - 2022-04-09
 ### Added
 - `Wit` type [PR #25](https://github.com/bnjjj/witgen/pull/25)
-- `Witgen` struct and expose `cargo-witgen` as a library [#PR 26](https://github.com/bnjjj/witgen/pull/25)
+- `Witgen` struct; expose `cargo-witgen` as a library; and add new arg `input_dir` [#PR 26](https://github.com/bnjjj/witgen/pull/25)
 ### Changed
  - Use `syn-file-expand` instead of Cargo [PR #25](https://github.com/bnjjj/witgen/pull/25)
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [0.12.0] - 2022-04-09
 ### Added
 - `Wit` type [PR #25](https://github.com/bnjjj/witgen/pull/25)
+- `Witgen` struct and expose `cargo-witgen` as a library [#PR 26](https://github.com/bnjjj/witgen/pull/25)
 ### Changed
  - Use `syn-file-expand` instead of Cargo [PR #25](https://github.com/bnjjj/witgen/pull/25)
 ---

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ witgen_macro_helper = { path = "crates/witgen_macro_helper"}
 syn = { version = "1.0.82", features = ["full", "extra-traits"] }
 anyhow = "1.0.51"
 difference = "2.0.0"
+cargo-witgen = {path = "crates/cargo_witgen"}
 
 [workspace]
 members = ["crates/witgen_macro", "crates/cargo_witgen", "examples/my_witgen_example"]

--- a/crates/cargo_witgen/Cargo.toml
+++ b/crates/cargo_witgen/Cargo.toml
@@ -20,3 +20,11 @@ cargo_metadata = "0.14.1"
 clap = {version = "=3.1.8", features = ["derive", "cargo"]}
 clap_derive = "=3.1.7"
 witgen_macro_helper= {path= "../witgen_macro_helper"}
+
+[lib]
+name = "cargo_witgen"
+path = "src/lib.rs"
+
+[[bin]]
+name = "cargo_witgen"
+path = "src/main.rs"

--- a/crates/cargo_witgen/Cargo.toml
+++ b/crates/cargo_witgen/Cargo.toml
@@ -20,6 +20,8 @@ cargo_metadata = "0.14.1"
 clap = {version = "=3.1.8", features = ["derive", "cargo"]}
 clap_derive = "=3.1.7"
 witgen_macro_helper= {path= "../witgen_macro_helper"}
+syn = { version = "1.0.82", features = ["full", "extra-traits"] }
+
 
 [lib]
 name = "cargo_witgen"

--- a/crates/cargo_witgen/src/app.rs
+++ b/crates/cargo_witgen/src/app.rs
@@ -50,7 +50,7 @@ pub struct Witgen {
     #[clap(long, short = 's')]
     pub prefix_string: Vec<String>,
 
-    /// Print results to stdout instead of to file
+    /// Print results to stdout instead file
     #[clap(long)]
     pub stdout: bool,
 }

--- a/crates/cargo_witgen/src/app.rs
+++ b/crates/cargo_witgen/src/app.rs
@@ -30,8 +30,9 @@ pub struct Witgen {
     pub input: Option<PathBuf>,
 
     /// Specify input directory to generate wit definitions from
-    /// 
-    /// Will expect library: `<input_dir>/src/lib.rs`
+    ///
+    ///
+    /// Will expect library: `<input-dir>/src/lib.rs`
     #[clap(long, short = 'd', default_value = ".")]
     pub input_dir: PathBuf,
 

--- a/crates/cargo_witgen/src/lib.rs
+++ b/crates/cargo_witgen/src/lib.rs
@@ -1,0 +1,3 @@
+mod app;
+
+pub use app::Witgen;

--- a/crates/witgen_macro_helper/src/lib.rs
+++ b/crates/witgen_macro_helper/src/lib.rs
@@ -2,8 +2,8 @@
 use std::path::Path;
 
 use anyhow::{bail, Result};
-use syn_file_expand::read_full_crate_source_code;
-
+pub use syn_file_expand::read_full_crate_source_code;
+use syn::File;
 pub mod generator;
 mod wit;
 pub use wit::Wit;
@@ -14,10 +14,14 @@ pub fn parse_tokens(item: proc_macro2::TokenStream) -> Result<Wit> {
 }
 
 /// Read a crate starting from a single file then parse into Wit
-pub fn parse_crate_as_file(path: &Path) -> Result<Wit> {
+pub fn parse_crate_as_file(path: &Path) -> Result<File> {
     if let Ok(ast) = read_full_crate_source_code(path, |_| Ok(false)) {
-        Ok(ast.into())
+        Ok(ast)
     } else {
         bail!("Failed to parse crate source {:?}", path)
     }
+}
+
+pub fn parse_file(file: File) -> Wit {
+  file.into()
 }

--- a/crates/witgen_macro_helper/src/lib.rs
+++ b/crates/witgen_macro_helper/src/lib.rs
@@ -1,3 +1,8 @@
+//! This crate provides a way to parse a whole crate as a file and then parse this into a `Wit` type.
+//! Currently this is a wrapper type for `syn` types.
+//! 
+//! 
+//! 
 #![deny(warnings)]
 use std::path::Path;
 
@@ -8,20 +13,27 @@ pub mod generator;
 mod wit;
 pub use wit::Wit;
 
-/// Parse proc_macro2 tokens into Wit
-pub fn parse_tokens(item: proc_macro2::TokenStream) -> Result<Wit> {
-    item.try_into()
+/// Convence function for
+/// ```
+/// let wit: Result<Wit> = tokens.try_into()
+/// ```
+pub fn parse_tokens(tokens: proc_macro2::TokenStream) -> Result<Wit> {
+    tokens.try_into()
 }
 
-/// Read a crate starting from a single file then parse into Wit
+/// Read a crate starting from a single file then parse into a file
 pub fn parse_crate_as_file(path: &Path) -> Result<File> {
-    if let Ok(ast) = read_full_crate_source_code(path, |_| Ok(false)) {
-        Ok(ast)
+    if let Ok(file) = read_full_crate_source_code(path, |_| Ok(false)) {
+        Ok(file)
     } else {
         bail!("Failed to parse crate source {:?}", path)
     }
 }
 
+/// Convence function for
+/// ```
+/// let wit: Wit = file.into();
+/// ```
 pub fn parse_file(file: File) -> Wit {
   file.into()
 }

--- a/crates/witgen_macro_helper/src/wit.rs
+++ b/crates/witgen_macro_helper/src/wit.rs
@@ -14,7 +14,7 @@ use syn::{
 
 /// Wit type that correspond to Rust Types using `syn`'s representation
 pub enum Wit {
-    File(Vec<Wit>),
+    Mod(Vec<Wit>, Vec<Attribute>),
     Record(ItemStruct),
     Function(ItemFn),
     Variant(ItemEnum),
@@ -35,7 +35,7 @@ impl Wit {
             Wit::Function(item) => Some(&item.attrs),
             Wit::Variant(item) => Some(&item.attrs),
             Wit::Type(item) => Some(&item.attrs),
-            Wit::File(_) => None,
+            Wit::Mod(_, attrs) => Some(attrs),
         }
     }
 
@@ -46,7 +46,7 @@ impl Wit {
     pub fn validate(self) -> Result<Self> {
         use Wit::*;
         match self {
-            File(_) => Ok(self),
+            Mod(_, _) => Ok(self),
             other if has_witgen_macro(&self.attrs()) => Ok(other),
             _ => bail!("Has no witgen macro"),
         }
@@ -65,13 +65,13 @@ fn has_witgen_macro(attrs: &Option<&[Attribute]>) -> bool {
 }
 
 fn is_witgen_macro(attr: &Attribute) -> bool {
-  // TODO: make this not use string comparison.
-  format!("{:#?}", attr.path).contains("witgen")
+    // TODO: make this not use string comparison.
+    format!("{:#?}", attr.path).contains("witgen")
 }
 
 impl From<syn::File> for Wit {
     fn from(file: syn::File) -> Self {
-        Wit::File(Wit::from_items(file.items))
+        Wit::Mod(Wit::from_items(file.items), vec![])
     }
 }
 
@@ -86,8 +86,9 @@ impl TryFrom<syn::Item> for Wit {
             Item::Type(item) => Wit::Type(item),
             Item::Mod(ItemMod {
                 content: Some((_, items)),
+                attrs,
                 ..
-            }) => Wit::File(Wit::from_items(items)),
+            }) => Wit::Mod(Wit::from_items(items), attrs),
             _ => bail!("cannot prase item"),
         }
         .validate()
@@ -120,11 +121,11 @@ impl TryFrom<proc_macro2::TokenStream> for Wit {
 }
 
 impl FromStr for Wit {
-  type Err = anyhow::Error;
+    type Err = anyhow::Error;
 
-  fn from_str(s: &str) -> Result<Self, Self::Err> {
-    s.try_into()
-  }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.try_into()
+    }
 }
 
 impl TryFrom<&str> for Wit {
@@ -139,7 +140,7 @@ impl Display for Wit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let doc = self.get_doc().unwrap_or(None).unwrap_or_default();
         let wit_str = match self {
-            Wit::File(file) => Ok(file
+            Wit::Mod(wit, _) => Ok(wit
                 .iter()
                 .map(ToString::to_string)
                 .collect::<Vec<String>>()

--- a/examples/my_witgen_example/index.wit
+++ b/examples/my_witgen_example/index.wit
@@ -3,6 +3,10 @@
 
 type string-alias = string
 
+type private-type = list<f32>
+
+type second-level = bool
+
 enum colors {
     red,
     green,

--- a/examples/my_witgen_example/src/extra_type.rs
+++ b/examples/my_witgen_example/src/extra_type.rs
@@ -1,2 +1,12 @@
 #[witgen::witgen]
 pub type StringAlias = String;
+
+
+mod private {
+  #[witgen::witgen]
+  type PrivateType = Vec<f32>;
+  mod second_level {
+    #[witgen::witgen]
+    type SecondLevel = bool;
+  }
+}

--- a/examples/my_witgen_example/src/extra_type.rs
+++ b/examples/my_witgen_example/src/extra_type.rs
@@ -1,12 +1,11 @@
 #[witgen::witgen]
 pub type StringAlias = String;
 
-
 mod private {
-  #[witgen::witgen]
-  type PrivateType = Vec<f32>;
-  mod second_level {
     #[witgen::witgen]
-    type SecondLevel = bool;
-  }
+    type PrivateType = Vec<f32>;
+    mod second_level {
+        #[witgen::witgen]
+        type SecondLevel = bool;
+    }
 }

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -116,5 +116,4 @@ fn use_string_alias(s: StringAlias) -> StringAlias {
     s
 }
 
-
 fn has_no_macro() {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -54,7 +54,7 @@ fn test_diff() {
         stdout: false,
         input: None,
     };
-    let wit = witgen.generate_str().unwrap();
+    let wit = witgen.generate_str(witgen.read_input().unwrap()).unwrap();
     let path = &PathBuf::from(&"examples/my_witgen_example/index.wit");
     let file_str = String::from_utf8(read(path).unwrap()).unwrap();
     assert_diff!(&file_str, &wit, "", 0);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,11 @@
-use std::{path::PathBuf, fs::read};
 use std::str::FromStr;
+use std::{fs::read, path::PathBuf};
 
 use anyhow::Result;
 use difference::assert_diff;
 use wit_parser::Interface;
 use witgen_macro_helper::Wit;
+use cargo_witgen::Witgen;
 
 fn parse_str(s: &str) -> Result<String> {
     Wit::from_str(s).map(|wit| wit.to_string())
@@ -18,7 +19,6 @@ fn parse(s: &str) {
     let res = parse_str(s).expect(s);
     parse_wit_str(&res).expect(&res);
 }
-
 
 #[test]
 fn enum_simple() {
@@ -44,13 +44,19 @@ enum MyEnum {
     parse(simple);
 }
 
-
 #[test]
 fn test_diff() {
-  let wit = witgen_macro_helper::parse_crate_as_file(&PathBuf::from(&"examples/my_witgen_example/src/lib.rs")).unwrap();
-  let path = &PathBuf::from(&"examples/my_witgen_example/index.wit");
-  let file_str = String::from_utf8(read(path).unwrap()).unwrap();
-  let (_, rest) = file_str.split_once("\n").unwrap();
-  assert_diff!(rest.trim_matches('\n'), &wit.to_string(), "", 1); 
-
+    let witgen = Witgen {
+        input: PathBuf::from(
+          &"examples/my_witgen_example/src/lib.rs",
+      ),
+        output:PathBuf::from(&"index.wit"),
+        prefix_file:vec![],
+        prefix_string:vec![],
+        stdout: false,
+    };
+    let wit = witgen.generate_str().unwrap();
+    let path = &PathBuf::from(&"examples/my_witgen_example/index.wit");
+    let file_str = String::from_utf8(read(path).unwrap()).unwrap();
+    assert_diff!(&file_str, &wit, "", 0);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -47,13 +47,15 @@ enum MyEnum {
 #[test]
 fn test_diff() {
     let witgen = Witgen {
-        input: PathBuf::from(
-          &"examples/my_witgen_example/src/lib.rs",
+        input_dir: PathBuf::from(
+          &"examples/my_witgen_example",
       ),
         output:PathBuf::from(&"index.wit"),
         prefix_file:vec![],
         prefix_string:vec![],
         stdout: false,
+        input: None,
+
     };
     let wit = witgen.generate_str().unwrap();
     let path = &PathBuf::from(&"examples/my_witgen_example/index.wit");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 use std::{fs::read, path::PathBuf};
 
 use anyhow::Result;
+use cargo_witgen::Witgen;
 use difference::assert_diff;
 use wit_parser::Interface;
 use witgen_macro_helper::Wit;
-use cargo_witgen::Witgen;
 
 fn parse_str(s: &str) -> Result<String> {
     Wit::from_str(s).map(|wit| wit.to_string())
@@ -47,15 +47,12 @@ enum MyEnum {
 #[test]
 fn test_diff() {
     let witgen = Witgen {
-        input_dir: PathBuf::from(
-          &"examples/my_witgen_example",
-      ),
-        output:PathBuf::from(&"index.wit"),
-        prefix_file:vec![],
-        prefix_string:vec![],
+        input_dir: PathBuf::from(&"examples/my_witgen_example"),
+        output: PathBuf::from(&"index.wit"),
+        prefix_file: vec![],
+        prefix_string: vec![],
         stdout: false,
         input: None,
-
     };
     let wit = witgen.generate_str().unwrap();
     let path = &PathBuf::from(&"examples/my_witgen_example/index.wit");


### PR DESCRIPTION
This creates a new `Witgen` struct that handles generating the `wit` string and its output.  This way other applications (specifically [witme](https://github.com/AhaLabs/witme)) can use `#[clap(flatten)]` to inject it into their subcommand.