### PR TITLE
fix: rename `cargo_witgen` to `cargo-witgen`

### DIFF
--- a/crates/cargo_witgen/Cargo.toml
+++ b/crates/cargo_witgen/Cargo.toml
@@ -28,5 +28,5 @@ name = "cargo_witgen"
 path = "src/lib.rs"
 
 [[bin]]
-name = "cargo_witgen"
+name = "cargo-witgen"
 path = "src/main.rs"


### PR DESCRIPTION
fixes #27