### PR TITLE
Feat: depend on parser and update syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["wasm", "development-tools", "encoding"]
 witgen_macro = { path = "crates/witgen_macro", version = "0.13" }
 
 [dev-dependencies]
-wit-parser = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f" }
+wit-parser = { version = "0.1.0", package = "aha-wit-parser"}
 witgen_macro_helper = { path = "crates/witgen_macro_helper", version = "0.13" }
 syn = { version = "1.0.82", features = ["full", "extra-traits"] }
 anyhow = "1.0.51"

--- a/crates/cargo_witgen/src/app.rs
+++ b/crates/cargo_witgen/src/app.rs
@@ -5,8 +5,8 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
-use witgen_macro_helper::{Wit, parse_crate_as_file};
 use syn::File;
+use witgen_macro_helper::{parse_crate_as_file, Wit};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -56,19 +56,19 @@ pub struct Witgen {
 }
 
 impl Witgen {
-
     pub fn read_input(&self) -> Result<File> {
-              // TODO: figure out how to avoid the clone()
-              let input = self.input
-              .as_ref()
-              .map_or_else(|| self.input_dir.join("src/lib.rs"), |i| i.clone());
-  
-          if !input.exists() {
-              bail!("input {:?} doesn't exist", input);
-          }
-          parse_crate_as_file(&input)
+        // TODO: figure out how to avoid the clone()
+        let input = self
+            .input
+            .as_ref()
+            .map_or_else(|| self.input_dir.join("src/lib.rs"), |i| i.clone());
 
+        if !input.exists() {
+            bail!("input {:?} doesn't exist", input);
+        }
+        parse_crate_as_file(&input)
     }
+
     pub fn generate_str(&self, file: File) -> Result<String> {
         let wit: Wit = file.into();
         let mut wit_str = format!("// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v{}) \n\n", env!("CARGO_PKG_VERSION"));

--- a/crates/witgen_macro_helper/src/generator.rs
+++ b/crates/witgen_macro_helper/src/generator.rs
@@ -224,7 +224,7 @@ pub fn gen_wit_function(func: &ItemFn) -> Result<String> {
                 .map(|f| f.to_wit())
                 .collect::<Result<Vec<String>>>()?
                 .join(", ");
-            writeln!(&mut content, " -> ({})", tuple_fields).context("cannot write return type")?;
+            writeln!(&mut content, " -> tuple<{}>", tuple_fields).context("cannot write return type")?;
         } else {
             writeln!(&mut content, " -> {}", return_ty.to_wit()?)
                 .context("cannot write return type")?;

--- a/crates/witgen_macro_helper/src/lib.rs
+++ b/crates/witgen_macro_helper/src/lib.rs
@@ -1,14 +1,14 @@
 //! This crate provides a way to parse a whole crate as a file and then parse this into a `Wit` type.
 //! Currently this is a wrapper type for `syn` types.
-//! 
-//! 
-//! 
+//!
+//!
+//!
 #![deny(warnings)]
 use std::path::Path;
 
 use anyhow::{bail, Result};
-pub use syn_file_expand::read_full_crate_source_code;
 use syn::File;
+pub use syn_file_expand::read_full_crate_source_code;
 pub mod generator;
 mod wit;
 pub use wit::Wit;
@@ -35,5 +35,5 @@ pub fn parse_crate_as_file(path: &Path) -> Result<File> {
 /// let wit: Wit = file.into();
 /// ```
 pub fn parse_file(file: File) -> Wit {
-  file.into()
+    file.into()
 }

--- a/crates/witgen_macro_helper/src/wit.rs
+++ b/crates/witgen_macro_helper/src/wit.rs
@@ -8,8 +8,8 @@ use anyhow::{bail, Result};
 use heck::ToKebabCase;
 use quote::ToTokens;
 use syn::{
-    parse2 as parse, Attribute, Item, ItemEnum, ItemFn, ItemMod, ItemStruct, ItemType,
-    Type as SynType, TypeReference, File
+    parse2 as parse, Attribute, File, Item, ItemEnum, ItemFn, ItemMod, ItemStruct, ItemType,
+    Type as SynType, TypeReference,
 };
 
 /// Wit type that correspond to Rust Types using `syn`'s representation

--- a/crates/witgen_macro_helper/src/wit.rs
+++ b/crates/witgen_macro_helper/src/wit.rs
@@ -250,8 +250,11 @@ impl ToWitType for SynType {
                             }
                             "usize" => String::from("u64"),
                             "isize" => String::from("i64"),
-                            ident @ ("f32" | "f64" | "u8" | "u16" | "u32" | "u64" | "char"
-                            | "bool") => ident.to_string(),
+                            ident @ ("u8" | "u16" | "u32" | "u64" | "char" | "bool") => {
+                                ident.to_string()
+                            }
+                            "f32" => "float32".to_string(),
+                            "f64" => "float64".to_string(),
                             ident => {
                                 let ident_formatted = ident.to_string().to_kebab_case();
                                 is_known_keyword(&ident_formatted)?;
@@ -302,8 +305,8 @@ pub(crate) fn is_known_keyword(ident: &str) -> Result<()> {
             | "s16"
             | "s32"
             | "s64"
-            | "f32"
-            | "f64"
+            | "float32"
+            | "float64"
             | "char"
             | "handle"
             | "record"

--- a/examples/my_witgen_example/Cargo.toml
+++ b/examples/my_witgen_example/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-witgen = { path = "../../."}
+witgen = { path = "../.." }

--- a/examples/my_witgen_example/index.wit
+++ b/examples/my_witgen_example/index.wit
@@ -41,7 +41,7 @@ record with-named-fields-big-example {
     b: bool,
     s: string,
     a: list<u32>,
-    a-tuple: tuple<float64, list<tuple<u32,with-named-fields>>>
+    a-tuple: tuple<float64, list<tuple<u32,my-enum>>>
 }
 
 test-simple: function(array: list<u8>) -> string
@@ -53,9 +53,9 @@ record init-args {
     metadata: nft-contract-metadata
 }
 
-test-array: function(other: list<u8>, number: u8, othernum: s32) -> (string, u64)
+test-array: function(other: list<u8>, number: u8, othernum: s32) -> tuple<string, u64>
 
-test-vec: function(other: list<u8>, number: u8, othernum: s32) -> (string, u64)
+test-vec: function(other: list<u8>, number: u8, othernum: s32) -> tuple<string, u64>
 
 test-option: function(other: list<u8>, number: u8, othernum: s32) -> option<tuple<string, u64>>
 
@@ -86,7 +86,7 @@ variant test-enum {
 }
 
 
-test-tuple: function(other: list<u8>, test-struct: test-struct, other-enum: test-enum) -> (string, s64)
+test-tuple: function(other: list<u8>, test-struct: test-struct, other-enum: test-enum) -> tuple<string, s64>
 
 record has-hash-map {
     map: list<tuple<string,test-struct>>

--- a/examples/my_witgen_example/index.wit
+++ b/examples/my_witgen_example/index.wit
@@ -3,7 +3,7 @@
 
 type string-alias = string
 
-type private-type = list<f32>
+type private-type = list<float32>
 
 type second-level = bool
 
@@ -15,7 +15,7 @@ enum colors {
 
 
 variant my-enum {
-    unit,
+    unit-type,
     tuple-variant(tuple<string, s32>),
 }
 
@@ -23,7 +23,7 @@ variant my-enum {
 variant with-named-fields {
     ///  Example variant with named fields
     example(with-named-fields-example),
-    unit,
+    unit-type,
     a-tuple(string),
     ///  Example of a big named field
     big-example(with-named-fields-big-example),
@@ -41,7 +41,7 @@ record with-named-fields-big-example {
     b: bool,
     s: string,
     a: list<u32>,
-    a-tuple: tuple<f64, list<tuple<u32,with-named-fields>>>
+    a-tuple: tuple<float64, list<tuple<u32,with-named-fields>>>
 }
 
 test-simple: function(array: list<u8>) -> string
@@ -78,8 +78,8 @@ record test-struct {
 
 ///  Documentation over enum
 variant test-enum {
-    ///  Doc comment over Unit variant in struct
-    unit,
+    ///  Doc comment over UnitType variant in struct
+    unit-type,
     number(u64),
     ///  Doc comment over String variant in struct
     string-variant(string),
@@ -93,3 +93,7 @@ record has-hash-map {
 }
 
 use-string-alias: function(s: string-alias) -> string-alias
+
+type float32-bit = float32
+
+type float64-bit = float64

--- a/examples/my_witgen_example/index.wit
+++ b/examples/my_witgen_example/index.wit
@@ -1,4 +1,4 @@
-// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.12.0) 
+// This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (cargo-witgen v0.13.0) 
 
 
 type string-alias = string

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -35,7 +35,7 @@ enum WithNamedFields {
         b: bool,
         s: String,
         a: Vec<u32>,
-        a_tuple: (f64, HashMap<u32, WithNamedFields>),
+        a_tuple: (f64, HashMap<u32, MyEnum>),
     },
 }
 

--- a/examples/my_witgen_example/src/lib.rs
+++ b/examples/my_witgen_example/src/lib.rs
@@ -15,7 +15,7 @@ enum Colors {
 
 #[witgen]
 enum MyEnum {
-    Unit,
+    UnitType,
     TupleVariant(String, i32),
 }
 
@@ -26,7 +26,7 @@ enum WithNamedFields {
         /// Doc for inner string
         name: String,
     },
-    Unit,
+    UnitType,
     ATuple(String),
     /// Example of a big named field
     BigExample {
@@ -94,8 +94,8 @@ struct TestStruct {
 /// Documentation over enum
 #[witgen]
 enum TestEnum {
-    /// Doc comment over Unit variant in struct
-    Unit,
+    /// Doc comment over UnitType variant in struct
+    UnitType,
     Number(u64),
     /// Doc comment over String variant in struct
     StringVariant(String),
@@ -117,3 +117,9 @@ fn use_string_alias(s: StringAlias) -> StringAlias {
 }
 
 fn has_no_macro() {}
+
+#[witgen]
+type Float32Bit = f32;
+
+#[witgen]
+type Float64Bit = f64;

--- a/tests/files/success.rs
+++ b/tests/files/success.rs
@@ -83,3 +83,9 @@ struct HasHashMap {
 }
 
 pub fn main(){}
+
+#[witgen]
+type Float32 = f32;
+
+#[witgen]
+type Float64 = f64;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -54,8 +54,22 @@ fn test_diff() {
         stdout: false,
         input: None,
     };
+    
     let wit = witgen.generate_str(witgen.read_input().unwrap()).unwrap();
+    parse_wit_str(&wit).expect("Failed to parse example file");
     let path = &PathBuf::from(&"examples/my_witgen_example/index.wit");
     let file_str = String::from_utf8(read(path).unwrap()).unwrap();
     assert_diff!(&file_str, &wit, "", 0);
+}
+
+#[test]
+fn floats() {
+    let simple = r#"
+#[witgen]
+type Float32Bit = f32;
+
+#[witgen]
+type Float64Bit = f64;
+"#;
+    println!("{:?}", parse_wit_str(&parse_str(simple).unwrap()).unwrap())
 }


### PR DESCRIPTION
This updates the generated wit to comply with the newest syntax.

- `f32/f64` --> `float32/float64`. (Not sure why this decision was made. Why make it longer?)
- Multi-value returns are now tuples
- Can no longer have recursive type definitions.