### PR TITLE
feat: Add CI plan to release and publish on a git tag (#18)

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -1,9 +1,4 @@
-name: release
-
-# on:
-#   create:
-#     tags:
-#       - v*
+name: release-patch
 
 on:
   workflow_dispatch:
@@ -36,10 +31,6 @@ jobs:
         with:
           toolchain: stable
           override: true
-      # - uses: actions-rs/cargo@v1
-      #   with:
-      #     command: install
-      #     args: cargo-workspaces
       - uses: actions-rs/cargo@v1
         with:
           command: install
@@ -48,12 +39,6 @@ jobs:
         with:
           command: login
           args: ${{secrets.CRATES_IO_TOKEN}}
-      # - uses: actions-rs/cargo@v1
-      #   with:
-      #     command: workspaces
-      #     args: publish --no-git-tag --no-git-commit -y
-      # - name: Get Version
-      #   run: echo "version=${GITHUB_REF_NAME:1}" >> $GITHUB_OUTPUT
       - uses: actions-rs/cargo@v1
         with:
           command: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,31 @@ jobs:
         with:
           toolchain: stable
           override: true
+      # - uses: actions-rs/cargo@v1
+      #   with:
+      #     command: install
+      #     args: cargo-workspaces
       - uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-workspaces
+          args: cargo-release
       - uses: actions-rs/cargo@v1
         with:
           command: login
           args: ${{secrets.CRATES_IO_TOKEN}}
+      # - uses: actions-rs/cargo@v1
+      #   with:
+      #     command: workspaces
+      #     args: publish --no-git-tag --no-git-commit -y
+      - name: Get Version
+        run: echo "version=${GITHUB_REF_NAME:1}" >> $GITHUB_OUTPUT
       - uses: actions-rs/cargo@v1
         with:
-          command: workspaces
-          args: publish --no-git-tag --no-git-commit -y
+          command: release
+          args: |
+            --workspace 
+            --exclude my_witgen_example 
+            --exclude example-dep 
+            ${{ steps.vars.output.version }}
+            
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
 name: release
 
+# on:
+#   create:
+#     tags:
+#       - v*
+
 on:
-  create:
-    tags:
-      - v*
+  workflow_dispatch:
+    secrets:
+      CRATES_IO_TOKEN:
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -46,8 +52,8 @@ jobs:
       #   with:
       #     command: workspaces
       #     args: publish --no-git-tag --no-git-commit -y
-      - name: Get Version
-        run: echo "version=${GITHUB_REF_NAME:1}" >> $GITHUB_OUTPUT
+      # - name: Get Version
+      #   run: echo "version=${GITHUB_REF_NAME:1}" >> $GITHUB_OUTPUT
       - uses: actions-rs/cargo@v1
         with:
           command: release
@@ -55,6 +61,6 @@ jobs:
             --workspace 
             --exclude my_witgen_example 
             --exclude example-dep 
-            ${{ steps.vars.output.version }}
+            patch
             
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: release
+
+on:
+  create:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo
+          restore-keys: ${{ runner.os }}-cargo
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-workspaces
+      - uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{secrets.CRATES_IO_TOKEN}}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: workspaces
+          args: publish --no-git-tag --no-git-commit -y


### PR DESCRIPTION
Maybe this can serve as a starting point.

This would:
* Trigger for any tag starting with a `v`
* Set up a cache for some files
* Ensure the latest stable version of rust is installed
* Install [cargo-workspaces](https://crates.io/crates/cargo-workspaces)
* Log in to crates.io (CRATES_IO_TOKEN-secret needs to be set up)
*  Publish all crates in the workspace using cargo-workspaces